### PR TITLE
Disable Datagrid Multiselect

### DIFF
--- a/FocalPointDMSClient/App.xaml
+++ b/FocalPointDMSClient/App.xaml
@@ -49,6 +49,7 @@
             <Setter Property="BorderBrush" Value="#333333"/>
             <Setter Property="GridLinesVisibility" Value="None"/>
             <Setter Property="HeadersVisibility" Value="Column"/>
+            <Setter Property="SelectionMode" Value="Single"/>
         </Style>
 
         <Style TargetType="DataGridColumnHeader">


### PR DESCRIPTION
Added single selection mode to datagrid style.  Multiselect is now disabled for all datagrids.

Closes #19 